### PR TITLE
Use sshuttle PID file if present

### DIFF
--- a/vpn-down.sh
+++ b/vpn-down.sh
@@ -13,7 +13,11 @@ if [ ! -f ".vmname" ]; then
   exit 1
 fi
 
-SSHUTTLEPID=$(pgrep sshuttle)
+if [[ -f "$BASE_DIR/sshuttle.pid" ]]; then
+  SSHUTTLEPID=$(cat "$BASE_DIR/sshuttle.pid")
+else
+  SSHUTTLEPID=$(pgrep sshuttle)
+fi
 if [ -n "$SSHUTTLEPID" ]; then
   echo "Stopping running sshuttle instance with PID $SSHUTTLEPID"
   kill "$SSHUTTLEPID"


### PR DESCRIPTION
This checks for the default sshuttle PID file and uses it for the PID when present. This is more accurate, but more importantly (for me) allows a clean shutdown on Mac OS, as BSD pgrep is a little different to GNU pgrep.