### PR TITLE
Remove dynamic vm name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   # base box: Ubuntu 20.04 LTS (Focal Fossa)
   config.vm.box = "ubuntu/focal64"
 
-  vmhostname = "vpn-anyconnect" # derive the guest hostname from host's hostname
+  vmhostname = "vpn-anyconnect"
   config.vm.define vmhostname # name in Vagrant (instead of "default")
   config.vm.hostname = vmhostname # name of host inside the VM, i.e. `/etc/hostname`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   # base box: Ubuntu 20.04 LTS (Focal Fossa)
   config.vm.box = "ubuntu/focal64"
 
-  vmhostname = `hostname`.strip+"-anyconnect" # derive the guest hostname from host's hostname
+  vmhostname = "vpn-anyconnect" # derive the guest hostname from host's hostname
   config.vm.define vmhostname # name in Vagrant (instead of "default")
   config.vm.hostname = vmhostname # name of host inside the VM, i.e. `/etc/hostname`
 


### PR DESCRIPTION
On macOS I frequently have different hostnames depending on the network I'm in. This causes Vagrant to bring up a new VM instead of reusing the old one. 

This change removes this dynamic part of the Vagrant VM name and just sets it to "vpn-anyconnect".